### PR TITLE
Fix backend server issue by correcting filename casing

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ app.use(cors());
 
 const GITHUB_PAT = process.env.GITHUB_PAT;
 const GITHUB_REPO = 'dg143143/1';
-const USERS_FILE_PATH = 'users.json';
+const USERS_FILE_PATH = 'USERS.JSON';
 
 // --- GitHub API Functions (now on the server) ---
 


### PR DESCRIPTION
The backend server was failing to read user data from the GitHub repository due to a filename casing issue. The server was hardcoded to read 'users.json', but the file in the repository is named 'USERS.JSON'. This change corrects the filename in server.js to 'USERS.JSON' to resolve the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent user data from loading or saving correctly on case‑sensitive environments, improving reliability across different platforms and deployments. This change ensures consistent access to stored user information and reduces intermittent errors some users experienced when reading or writing data. No UI changes or user action are required; behavior remains the same with improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->